### PR TITLE
Adding toggle results pane and execute query

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
             {
                 "key": "ctrl+m",
                 "command": "runCurrentQueryWithActualPlanKeyboardAction"
+            },
+            {
+                "key": "ctrl+e",
+                "command": "runQueryKeyboardAction"
+            },
+            {
+                "key": "ctrl+r",
+                "command": "toggleQueryResultsKeyboardAction"
             }
         ]
     }


### PR DESCRIPTION
CTRL + R will toggle hiding or showing the results pane after a query has been executed.
CTRL + E will execute the highlighted text or the entire script in the active query tab if nothing is highlighted.